### PR TITLE
Tildel veiledere lokalt før vi oppdaterer amt-arrangor

### DIFF
--- a/src/main/kotlin/no/nav/tiltaksarrangor/service/AnsattService.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/service/AnsattService.kt
@@ -14,6 +14,7 @@ import no.nav.tiltaksarrangor.repositories.model.KoordinatorDeltakerlisteDbo
 import no.nav.tiltaksarrangor.repositories.model.VeilederForDeltakerDbo
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
 
 @Component
@@ -61,8 +62,10 @@ class AnsattService(
 		ansattRepository.deleteKoordinatorDeltakerliste(ansattId = ansattId, deltakerliste = KoordinatorDeltakerlisteDbo(deltakerlisteId))
 	}
 
+	@Transactional
 	fun tildelVeiledereForDeltaker(deltakerId: UUID, arrangorId: UUID, veiledereForDeltaker: List<VeilederForDeltakerDbo>) {
 		val gamleVeiledereForDeltaker = ansattRepository.getVeiledereForDeltaker(deltakerId)
+		ansattRepository.updateVeiledereForDeltaker(deltakerId = deltakerId, veiledere = veiledereForDeltaker)
 		amtArrangorClient.oppdaterVeilederForDeltaker(
 			deltakerId = deltakerId,
 			oppdaterVeiledereForDeltakerRequest = createOppdaterVeiledereForDeltakerRequest(
@@ -71,7 +74,6 @@ class AnsattService(
 				gamleVeiledereForDeltaker = gamleVeiledereForDeltaker.map { VeilederForDeltakerDbo(it.ansattPersonaliaDbo.id, it.veilederDeltakerDbo.veilederType) }
 			)
 		)
-		ansattRepository.updateVeiledereForDeltaker(deltakerId = deltakerId, veiledere = veiledereForDeltaker)
 	}
 
 	fun getKoordinatorerForDeltakerliste(deltakerlisteId: UUID, arrangorId: UUID): List<AnsattPersonaliaDbo> {


### PR DESCRIPTION
Hvis vi oppdaterer databasen lokalt først, vil det hindre at vi ender opp med at vi leser samme oppdateringen på kafka før vi er ferdig med databaseendringene. Databaseendringen må rulles tilbake hvis amt-arrangor feiler, så vi må ha en transaksjon.