### PR TITLE
proxy-api mot unleash for frontend

### DIFF
--- a/src/main/kotlin/no/nav/tiltaksarrangor/unleash/UnleashController.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/unleash/UnleashController.kt
@@ -1,0 +1,22 @@
+package no.nav.tiltaksarrangor.unleash
+
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.tiltaksarrangor.utils.Issuer
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/unleash/api/feature")
+class UnleashController(
+	private val unleashService: UnleashService
+) {
+	@GetMapping
+	@ProtectedWithClaims(issuer = Issuer.TOKEN_X)
+	fun getFeaturetoggles(
+		@RequestParam("feature") features: List<String>
+	): Map<String, Boolean> {
+		return unleashService.getFeaturetoggles(features)
+	}
+}

--- a/src/main/kotlin/no/nav/tiltaksarrangor/unleash/UnleashService.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/unleash/UnleashService.kt
@@ -8,6 +8,10 @@ import java.util.UUID
 class UnleashService(
 	private val unleash: DefaultUnleash
 ) {
+	fun getFeaturetoggles(features: List<String>): Map<String, Boolean> {
+		return features.associateWith { unleash.isEnabled(it) }
+	}
+
 	fun skalViseKurs(deltakerlisteId: UUID): Boolean {
 		return if (erPilot(deltakerlisteId)) {
 			true

--- a/src/test/kotlin/no/nav/tiltaksarrangor/unleash/UnleashControllerTest.kt
+++ b/src/test/kotlin/no/nav/tiltaksarrangor/unleash/UnleashControllerTest.kt
@@ -1,0 +1,32 @@
+package no.nav.tiltaksarrangor.unleash
+
+import io.kotest.matchers.shouldBe
+import no.nav.tiltaksarrangor.IntegrationTest
+import org.junit.jupiter.api.Test
+
+class UnleashControllerTest : IntegrationTest() {
+	@Test
+	fun `getFeaturetoggles - ikke autentisert - returnerer 401`() {
+		val response = sendRequest(
+			method = "GET",
+			path = "/unleash/api/feature?feature=amt-tiltaksarrangor-flate.driftsmelding&amt-tiltaksarrangor-flate.eksponer-kurs"
+		)
+
+		response.code shouldBe 401
+	}
+
+	@Test
+	fun `getFeaturetoggles - autentisert - returnerer toggles`() {
+		val response = sendRequest(
+			method = "GET",
+			path = "/unleash/api/feature?feature=amt-tiltaksarrangor-flate.driftsmelding&feature=amt-tiltaksarrangor-flate.eksponer-kurs",
+			headers = mapOf("Authorization" to "Bearer ${getTokenxToken(fnr = "12345678910")}")
+		)
+
+		val expectedJson = """
+			{"amt-tiltaksarrangor-flate.driftsmelding":false,"amt-tiltaksarrangor-flate.eksponer-kurs":false}
+		""".trimIndent()
+		response.code shouldBe 200
+		response.body?.string() shouldBe expectedJson
+	}
+}


### PR DESCRIPTION
Man må sende med apitoken for å snakke med unleash, og det får vi ikke gjort på noen trygg måte fra den delen av frontenden som vi styrer selv. Dermed kan det være greit med et proxy-api i bff-en. Andre i POAO har også løst det på denne måten. 