### PR TITLE
sletter ansatte som ikke har noen arrangører knyttet til seg

### DIFF
--- a/src/main/kotlin/no/nav/tiltaksarrangor/ingest/IngestService.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/ingest/IngestService.kt
@@ -49,7 +49,7 @@ class IngestService(
 	}
 
 	fun lagreAnsatt(ansattId: UUID, ansatt: AnsattDto?) {
-		if (ansatt == null) {
+		if (ansatt == null || ansatt.arrangorer.isEmpty()) {
 			ansattRepository.deleteAnsatt(ansattId)
 			log.info("Slettet ansatt med id $ansattId")
 		} else {


### PR DESCRIPTION
https://trello.com/c/HI6UEY1z/1105-ansatte-som-ikke-lenger-har-roller-i-noen-bedrifter-blir-liggende-igjen-i-bff

Når en ansatt mister alle roller hos en arrangør produseres de på topic uten arrangøren. Når den ansatte ikke har noen roller hos noen arrangører så vil listen være tom, og da bør det være trygt å slette dem fra bff-en. 