### PR TITLE
Ingest sluttdato deltaker

### DIFF
--- a/src/main/kotlin/no/nav/tiltaksarrangor/ingest/IngestService.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/ingest/IngestService.kt
@@ -109,9 +109,14 @@ class IngestService(
 		} else if (status.type == DeltakerStatus.IKKE_AKTUELL && deltarPaKurs && deltakerRepository.getDeltaker(id) == null) {
 			return false
 		} else if (status.type in AVSLUTTENDE_STATUSER) {
-			return !LocalDateTime.now().isAfter(status.gyldigFra.plusWeeks(2))
+			return harNyligSluttet()
 		}
 		return true
+	}
+
+	private fun DeltakerDto.harNyligSluttet(): Boolean {
+		return !LocalDateTime.now().isAfter(status.gyldigFra.plusWeeks(2)) &&
+			(sluttdato == null || sluttdato.isAfter(LocalDate.now().minusDays(14)))
 	}
 
 	private fun toDeltakerlisteDbo(deltakerlisteDto: DeltakerlisteDto): DeltakerlisteDbo {

--- a/src/main/kotlin/no/nav/tiltaksarrangor/ingest/model/DeltakerlisteDto.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/ingest/model/DeltakerlisteDto.kt
@@ -1,5 +1,6 @@
 package no.nav.tiltaksarrangor.ingest.model
 
+import no.nav.tiltaksarrangor.model.DeltakerlisteStatus
 import java.time.LocalDate
 import java.util.UUID
 

--- a/src/main/kotlin/no/nav/tiltaksarrangor/koordinator/model/Deltakerliste.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/koordinator/model/Deltakerliste.kt
@@ -1,5 +1,6 @@
 package no.nav.tiltaksarrangor.koordinator.model
 
+import no.nav.tiltaksarrangor.model.DeltakerlisteStatus
 import java.time.LocalDate
 import java.util.UUID
 
@@ -10,13 +11,9 @@ data class Deltakerliste(
 	val arrangorNavn: String,
 	val startDato: LocalDate?,
 	val sluttDato: LocalDate?,
-	val status: Status,
+	val status: DeltakerlisteStatus,
 	val koordinatorer: List<Koordinator>,
 	val deltakere: List<Deltaker>,
 	val erKurs: Boolean,
 	val tiltakType: String
-) {
-	enum class Status {
-		PLANLAGT, GJENNOMFORES, AVSLUTTET
-	}
-}
+)

--- a/src/main/kotlin/no/nav/tiltaksarrangor/koordinator/service/KoordinatorService.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/koordinator/service/KoordinatorService.kt
@@ -185,7 +185,7 @@ class KoordinatorService(
 			arrangorNavn = overordnetArrangor?.navn ?: deltakerlisteMedArrangor.arrangorDbo.navn,
 			startDato = deltakerlisteMedArrangor.deltakerlisteDbo.startDato,
 			sluttDato = deltakerlisteMedArrangor.deltakerlisteDbo.sluttDato,
-			status = Deltakerliste.Status.valueOf(deltakerlisteMedArrangor.deltakerlisteDbo.status.name),
+			status = deltakerlisteMedArrangor.deltakerlisteDbo.status,
 			koordinatorer = koordinatorer.map {
 				Koordinator(
 					fornavn = it.fornavn,

--- a/src/main/kotlin/no/nav/tiltaksarrangor/model/DeltakerlisteStatus.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/model/DeltakerlisteStatus.kt
@@ -1,4 +1,4 @@
-package no.nav.tiltaksarrangor.ingest.model
+package no.nav.tiltaksarrangor.model
 
 enum class DeltakerlisteStatus {
 	PLANLAGT, GJENNOMFORES, AVSLUTTET

--- a/src/main/kotlin/no/nav/tiltaksarrangor/repositories/DeltakerRepository.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/repositories/DeltakerRepository.kt
@@ -1,9 +1,9 @@
 package no.nav.tiltaksarrangor.repositories
 
 import no.nav.tiltaksarrangor.ingest.model.AdresseDto
-import no.nav.tiltaksarrangor.ingest.model.DeltakerlisteStatus
 import no.nav.tiltaksarrangor.ingest.model.VurderingDto
 import no.nav.tiltaksarrangor.ingest.model.toPGObject
+import no.nav.tiltaksarrangor.model.DeltakerlisteStatus
 import no.nav.tiltaksarrangor.model.StatusType
 import no.nav.tiltaksarrangor.repositories.model.DeltakerDbo
 import no.nav.tiltaksarrangor.repositories.model.DeltakerMedDeltakerlisteDbo

--- a/src/main/kotlin/no/nav/tiltaksarrangor/repositories/DeltakerlisteRepository.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/repositories/DeltakerlisteRepository.kt
@@ -1,6 +1,6 @@
 package no.nav.tiltaksarrangor.repositories
 
-import no.nav.tiltaksarrangor.ingest.model.DeltakerlisteStatus
+import no.nav.tiltaksarrangor.model.DeltakerlisteStatus
 import no.nav.tiltaksarrangor.repositories.model.ArrangorDbo
 import no.nav.tiltaksarrangor.repositories.model.DeltakerlisteDbo
 import no.nav.tiltaksarrangor.repositories.model.DeltakerlisteMedArrangorDbo

--- a/src/main/kotlin/no/nav/tiltaksarrangor/repositories/EndringsmeldingRepository.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/repositories/EndringsmeldingRepository.kt
@@ -1,10 +1,10 @@
 package no.nav.tiltaksarrangor.repositories
 
 import no.nav.tiltaksarrangor.ingest.model.AdresseDto
-import no.nav.tiltaksarrangor.ingest.model.DeltakerlisteStatus
 import no.nav.tiltaksarrangor.ingest.model.EndringsmeldingType
 import no.nav.tiltaksarrangor.ingest.model.Innhold
 import no.nav.tiltaksarrangor.ingest.model.VurderingDto
+import no.nav.tiltaksarrangor.model.DeltakerlisteStatus
 import no.nav.tiltaksarrangor.model.Endringsmelding
 import no.nav.tiltaksarrangor.model.StatusType
 import no.nav.tiltaksarrangor.repositories.model.DeltakerDbo

--- a/src/main/kotlin/no/nav/tiltaksarrangor/repositories/model/DeltakerlisteDbo.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/repositories/model/DeltakerlisteDbo.kt
@@ -1,6 +1,6 @@
 package no.nav.tiltaksarrangor.repositories.model
 
-import no.nav.tiltaksarrangor.ingest.model.DeltakerlisteStatus
+import no.nav.tiltaksarrangor.model.DeltakerlisteStatus
 import java.time.LocalDate
 import java.util.UUID
 

--- a/src/test/kotlin/no/nav/tiltaksarrangor/ingest/IngestServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltaksarrangor/ingest/IngestServiceTest.kt
@@ -16,11 +16,11 @@ import no.nav.tiltaksarrangor.ingest.model.DeltakerPersonaliaDto
 import no.nav.tiltaksarrangor.ingest.model.DeltakerStatus
 import no.nav.tiltaksarrangor.ingest.model.DeltakerStatusDto
 import no.nav.tiltaksarrangor.ingest.model.DeltakerlisteDto
-import no.nav.tiltaksarrangor.ingest.model.DeltakerlisteStatus
 import no.nav.tiltaksarrangor.ingest.model.EndringsmeldingDto
 import no.nav.tiltaksarrangor.ingest.model.EndringsmeldingType
 import no.nav.tiltaksarrangor.ingest.model.Innhold
 import no.nav.tiltaksarrangor.ingest.model.NavnDto
+import no.nav.tiltaksarrangor.model.DeltakerlisteStatus
 import no.nav.tiltaksarrangor.model.Endringsmelding
 import no.nav.tiltaksarrangor.repositories.AnsattRepository
 import no.nav.tiltaksarrangor.repositories.ArrangorRepository

--- a/src/test/kotlin/no/nav/tiltaksarrangor/ingest/IngestServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltaksarrangor/ingest/IngestServiceTest.kt
@@ -473,6 +473,44 @@ class IngestServiceTest {
 	}
 
 	@Test
+	internal fun `lagreDeltaker - status HAR_SLUTTET for mindre enn to uker siden men sluttdato for mer enn 2 uker siden - lagres ikke i db `() {
+		val deltakerId = UUID.randomUUID()
+		val deltakerDto = DeltakerDto(
+			id = deltakerId,
+			deltakerlisteId = UUID.randomUUID(),
+			personalia = DeltakerPersonaliaDto(
+				personident = "10987654321",
+				navn = NavnDto("Fornavn", null, "Etternavn"),
+				kontaktinformasjon = DeltakerKontaktinformasjonDto("98989898", "epost@nav.no"),
+				skjermet = false,
+				adresse = getAdresse(),
+				adressebeskyttelse = null
+			),
+			status = DeltakerStatusDto(
+				type = DeltakerStatus.HAR_SLUTTET,
+				gyldigFra = LocalDate.now().minusWeeks(1).atStartOfDay(),
+				opprettetDato = LocalDateTime.now().minusWeeks(6)
+			),
+			dagerPerUke = null,
+			prosentStilling = null,
+			oppstartsdato = LocalDate.now().minusWeeks(5),
+			sluttdato = LocalDate.now().minusDays(15),
+			innsoktDato = LocalDate.now().minusMonths(2),
+			bestillingTekst = "Bestilling",
+			navKontor = "NAV Oslo",
+			navVeileder = DeltakerNavVeilederDto(UUID.randomUUID(), "Per Veileder", null, null),
+			skjult = null,
+			deltarPaKurs = false,
+			vurderingerFraArrangor = null
+		)
+
+		ingestService.lagreDeltaker(deltakerId, deltakerDto)
+
+		verify(exactly = 0) { deltakerRepository.insertOrUpdateDeltaker(any()) }
+		verify(exactly = 1) { deltakerRepository.deleteDeltaker(deltakerId) }
+	}
+
+	@Test
 	internal fun `lagreDeltaker - har adressebeskyttelse - lagres ikke i db `() {
 		val deltakerId = UUID.randomUUID()
 		val deltakerDto = DeltakerDto(

--- a/src/test/kotlin/no/nav/tiltaksarrangor/ingest/KafkaListenerTest.kt
+++ b/src/test/kotlin/no/nav/tiltaksarrangor/ingest/KafkaListenerTest.kt
@@ -12,7 +12,6 @@ import no.nav.tiltaksarrangor.ingest.model.DeltakerPersonaliaDto
 import no.nav.tiltaksarrangor.ingest.model.DeltakerStatus
 import no.nav.tiltaksarrangor.ingest.model.DeltakerStatusDto
 import no.nav.tiltaksarrangor.ingest.model.DeltakerlisteDto
-import no.nav.tiltaksarrangor.ingest.model.DeltakerlisteStatus
 import no.nav.tiltaksarrangor.ingest.model.EndringsmeldingDto
 import no.nav.tiltaksarrangor.ingest.model.EndringsmeldingType
 import no.nav.tiltaksarrangor.ingest.model.Innhold
@@ -24,6 +23,7 @@ import no.nav.tiltaksarrangor.ingest.model.toArrangorDbo
 import no.nav.tiltaksarrangor.ingest.model.toDeltakerDbo
 import no.nav.tiltaksarrangor.ingest.model.toEndringsmeldingDbo
 import no.nav.tiltaksarrangor.kafka.subscribeHvisIkkeSubscribed
+import no.nav.tiltaksarrangor.model.DeltakerlisteStatus
 import no.nav.tiltaksarrangor.model.Endringsmelding
 import no.nav.tiltaksarrangor.model.StatusType
 import no.nav.tiltaksarrangor.model.Veiledertype

--- a/src/test/kotlin/no/nav/tiltaksarrangor/ingest/jobs/RyddejobbTest.kt
+++ b/src/test/kotlin/no/nav/tiltaksarrangor/ingest/jobs/RyddejobbTest.kt
@@ -7,9 +7,9 @@ import io.mockk.mockk
 import no.nav.tiltaksarrangor.IntegrationTest
 import no.nav.tiltaksarrangor.ingest.jobs.leaderelection.LeaderElection
 import no.nav.tiltaksarrangor.ingest.model.AnsattRolle
-import no.nav.tiltaksarrangor.ingest.model.DeltakerlisteStatus
 import no.nav.tiltaksarrangor.ingest.model.EndringsmeldingType
 import no.nav.tiltaksarrangor.ingest.model.Innhold
+import no.nav.tiltaksarrangor.model.DeltakerlisteStatus
 import no.nav.tiltaksarrangor.model.Endringsmelding
 import no.nav.tiltaksarrangor.model.StatusType
 import no.nav.tiltaksarrangor.model.Veiledertype

--- a/src/test/kotlin/no/nav/tiltaksarrangor/koordinator/controller/DeltakerlisteAdminControllerTest.kt
+++ b/src/test/kotlin/no/nav/tiltaksarrangor/koordinator/controller/DeltakerlisteAdminControllerTest.kt
@@ -4,7 +4,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import no.nav.tiltaksarrangor.IntegrationTest
 import no.nav.tiltaksarrangor.ingest.model.AnsattRolle
-import no.nav.tiltaksarrangor.ingest.model.DeltakerlisteStatus
+import no.nav.tiltaksarrangor.model.DeltakerlisteStatus
 import no.nav.tiltaksarrangor.repositories.AnsattRepository
 import no.nav.tiltaksarrangor.repositories.ArrangorRepository
 import no.nav.tiltaksarrangor.repositories.DeltakerRepository

--- a/src/test/kotlin/no/nav/tiltaksarrangor/koordinator/controller/KoordinatorControllerTest.kt
+++ b/src/test/kotlin/no/nav/tiltaksarrangor/koordinator/controller/KoordinatorControllerTest.kt
@@ -4,9 +4,9 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import no.nav.tiltaksarrangor.IntegrationTest
 import no.nav.tiltaksarrangor.ingest.model.AnsattRolle
-import no.nav.tiltaksarrangor.ingest.model.DeltakerlisteStatus
 import no.nav.tiltaksarrangor.koordinator.model.LeggTilVeiledereRequest
 import no.nav.tiltaksarrangor.koordinator.model.VeilederRequest
+import no.nav.tiltaksarrangor.model.DeltakerlisteStatus
 import no.nav.tiltaksarrangor.model.StatusType
 import no.nav.tiltaksarrangor.model.Veiledertype
 import no.nav.tiltaksarrangor.repositories.AnsattRepository

--- a/src/test/kotlin/no/nav/tiltaksarrangor/koordinator/service/DeltakerlisteAdminServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltaksarrangor/koordinator/service/DeltakerlisteAdminServiceTest.kt
@@ -10,7 +10,7 @@ import io.mockk.just
 import io.mockk.mockk
 import no.nav.tiltaksarrangor.client.amtarrangor.AmtArrangorClient
 import no.nav.tiltaksarrangor.ingest.model.AnsattRolle
-import no.nav.tiltaksarrangor.ingest.model.DeltakerlisteStatus
+import no.nav.tiltaksarrangor.model.DeltakerlisteStatus
 import no.nav.tiltaksarrangor.model.exceptions.UnauthorizedException
 import no.nav.tiltaksarrangor.repositories.AnsattRepository
 import no.nav.tiltaksarrangor.repositories.ArrangorRepository

--- a/src/test/kotlin/no/nav/tiltaksarrangor/koordinator/service/KoordinatorServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltaksarrangor/koordinator/service/KoordinatorServiceTest.kt
@@ -11,10 +11,9 @@ import io.mockk.mockk
 import no.nav.tiltaksarrangor.client.amtarrangor.AmtArrangorClient
 import no.nav.tiltaksarrangor.client.amtarrangor.dto.VeilederAnsatt
 import no.nav.tiltaksarrangor.ingest.model.AnsattRolle
-import no.nav.tiltaksarrangor.ingest.model.DeltakerlisteStatus
-import no.nav.tiltaksarrangor.koordinator.model.Deltakerliste
 import no.nav.tiltaksarrangor.koordinator.model.LeggTilVeiledereRequest
 import no.nav.tiltaksarrangor.koordinator.model.VeilederRequest
+import no.nav.tiltaksarrangor.model.DeltakerlisteStatus
 import no.nav.tiltaksarrangor.model.Endringsmelding
 import no.nav.tiltaksarrangor.model.StatusType
 import no.nav.tiltaksarrangor.model.Veiledertype
@@ -330,7 +329,7 @@ class KoordinatorServiceTest {
 		koordinatorsDeltakerliste.arrangorNavn shouldBe "Overordnet arrangør AS"
 		koordinatorsDeltakerliste.startDato shouldBe LocalDate.of(2023, 2, 1)
 		koordinatorsDeltakerliste.sluttDato shouldBe null
-		koordinatorsDeltakerliste.status shouldBe Deltakerliste.Status.GJENNOMFORES
+		koordinatorsDeltakerliste.status shouldBe DeltakerlisteStatus.GJENNOMFORES
 		koordinatorsDeltakerliste.koordinatorer.size shouldBe 1
 		koordinatorsDeltakerliste.koordinatorer.find { it.fornavn == "Fornavn" && it.etternavn == "Etternavn" } shouldNotBe null
 		koordinatorsDeltakerliste.deltakere.size shouldBe 0

--- a/src/test/kotlin/no/nav/tiltaksarrangor/testutils/Testdata.kt
+++ b/src/test/kotlin/no/nav/tiltaksarrangor/testutils/Testdata.kt
@@ -2,13 +2,13 @@ package no.nav.tiltaksarrangor.testutils
 
 import no.nav.tiltaksarrangor.ingest.model.AdresseDto
 import no.nav.tiltaksarrangor.ingest.model.Bostedsadresse
-import no.nav.tiltaksarrangor.ingest.model.DeltakerlisteStatus
 import no.nav.tiltaksarrangor.ingest.model.EndringsmeldingType
 import no.nav.tiltaksarrangor.ingest.model.Innhold
 import no.nav.tiltaksarrangor.ingest.model.Kontaktadresse
 import no.nav.tiltaksarrangor.ingest.model.Matrikkeladresse
 import no.nav.tiltaksarrangor.ingest.model.Vegadresse
 import no.nav.tiltaksarrangor.ingest.model.VurderingDto
+import no.nav.tiltaksarrangor.model.DeltakerlisteStatus
 import no.nav.tiltaksarrangor.model.Endringsmelding
 import no.nav.tiltaksarrangor.model.StatusType
 import no.nav.tiltaksarrangor.model.Vurderingstype

--- a/src/test/kotlin/no/nav/tiltaksarrangor/veileder/controller/VeilederControllerTest.kt
+++ b/src/test/kotlin/no/nav/tiltaksarrangor/veileder/controller/VeilederControllerTest.kt
@@ -3,7 +3,7 @@ package no.nav.tiltaksarrangor.veileder.controller
 import io.kotest.matchers.shouldBe
 import no.nav.tiltaksarrangor.IntegrationTest
 import no.nav.tiltaksarrangor.ingest.model.AnsattRolle
-import no.nav.tiltaksarrangor.ingest.model.DeltakerlisteStatus
+import no.nav.tiltaksarrangor.model.DeltakerlisteStatus
 import no.nav.tiltaksarrangor.model.StatusType
 import no.nav.tiltaksarrangor.model.Veiledertype
 import no.nav.tiltaksarrangor.repositories.AnsattRepository


### PR DESCRIPTION
https://trello.com/c/geChn867/1205-endre-ingest-av-deltaker-i-tiltaksarrang%C3%B8r-bff-s%C3%A5-vi-ikke-lagrer-deltaker-med-sluttdato-langt-tilbake-i-tid

Jeg har også flyttet DeltakerlisteStatus bort fra ingest-pakken siden det ikke var der den ble brukt, samt fjernet en ekstra DeltakerlisteStatus som vi ikke trengte. Disse endringene er gjort i egen commit. 