### PR TITLE
Returner aktive forslag

### DIFF
--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -73,6 +73,8 @@ spec:
       value: dev-gcp:amt:amt-arrangor
     - name: AMT_ARRANGOR_AAD_CLIENT_ID
       value: api://dev-gcp.amt.amt-arrangor/.default
+    - name: AMT_PERSON_AAD_CLIENT_ID
+      value: api://dev-gcp.amt.amt-person-service/.default
 
   observability:
     autoInstrumentation:

--- a/.nais/nais-prod.yaml
+++ b/.nais/nais-prod.yaml
@@ -74,6 +74,8 @@ spec:
       value: prod-gcp:amt:amt-arrangor
     - name: AMT_ARRANGOR_AAD_CLIENT_ID
       value: api://prod-gcp.amt.amt-arrangor/.default
+    - name: AMT_PERSON_AAD_CLIENT_ID
+      value: api://prod-gcp.amt.amt-person-service/.default
 
   observability:
     autoInstrumentation:

--- a/src/main/kotlin/no/nav/tiltaksarrangor/client/amtperson/AmtPersonClient.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/client/amtperson/AmtPersonClient.kt
@@ -1,0 +1,40 @@
+package no.nav.tiltaksarrangor.client.amtperson
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.tiltaksarrangor.ingest.model.NavEnhet
+import no.nav.tiltaksarrangor.utils.JsonUtils.objectMapper
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class AmtPersonClient(
+	@Value("\${amt-person.url}") private val url: String,
+	private val amtPersonAADHttpClient: OkHttpClient,
+) {
+	private val log = LoggerFactory.getLogger(javaClass)
+
+	fun hentEnhet(id: UUID): NavEnhet {
+		val request =
+			Request.Builder()
+				.url("$url/api/nav-enhet/$id")
+				.get()
+				.build()
+
+		amtPersonAADHttpClient.newCall(request).execute().use { response ->
+			if (!response.isSuccessful) {
+				log.error(
+					"Kunne ikke hente nav-enhet med id $id fra amt-person-service. " +
+						"Status=${response.code} error=${response.body?.string()}",
+				)
+				error("Kunne ikke hente NAV-enhet fra amt-person-service")
+			}
+			val body = response.body ?: error("Body manglet i response")
+
+			return objectMapper.readValue(body.string())
+		}
+	}
+}

--- a/src/main/kotlin/no/nav/tiltaksarrangor/config/HttpClientConfig.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/config/HttpClientConfig.kt
@@ -20,15 +20,7 @@ class HttpClientConfig {
 		oAuth2AccessTokenService: OAuth2AccessTokenService,
 	): OkHttpClient {
 		val registrationName = "amt-tiltak-tokenx"
-		val clientProperties =
-			clientConfigurationProperties.registration[registrationName]
-				?: throw RuntimeException("Fant ikke config for $registrationName")
-		return OkHttpClient.Builder()
-			.connectTimeout(5, TimeUnit.SECONDS)
-			.readTimeout(5, TimeUnit.SECONDS)
-			.followRedirects(false)
-			.addInterceptor(bearerTokenInterceptor(clientProperties, oAuth2AccessTokenService))
-			.build()
+		return buildClient(registrationName, clientConfigurationProperties, oAuth2AccessTokenService)
 	}
 
 	@Bean
@@ -37,15 +29,7 @@ class HttpClientConfig {
 		oAuth2AccessTokenService: OAuth2AccessTokenService,
 	): OkHttpClient {
 		val registrationName = "amt-arrangor-tokenx"
-		val clientProperties =
-			clientConfigurationProperties.registration[registrationName]
-				?: throw RuntimeException("Fant ikke config for $registrationName")
-		return OkHttpClient.Builder()
-			.connectTimeout(5, TimeUnit.SECONDS)
-			.readTimeout(5, TimeUnit.SECONDS)
-			.followRedirects(false)
-			.addInterceptor(bearerTokenInterceptor(clientProperties, oAuth2AccessTokenService))
-			.build()
+		return buildClient(registrationName, clientConfigurationProperties, oAuth2AccessTokenService)
 	}
 
 	@Bean
@@ -55,15 +39,16 @@ class HttpClientConfig {
 		oAuth2AccessTokenService: OAuth2AccessTokenService,
 	): OkHttpClient {
 		val registrationName = "amt-arrangor-aad"
-		val clientProperties =
-			clientConfigurationProperties.registration[registrationName]
-				?: throw RuntimeException("Fant ikke config for $registrationName")
-		return OkHttpClient.Builder()
-			.connectTimeout(5, TimeUnit.SECONDS)
-			.readTimeout(5, TimeUnit.SECONDS)
-			.followRedirects(false)
-			.addInterceptor(bearerTokenInterceptor(clientProperties, oAuth2AccessTokenService))
-			.build()
+		return buildClient(registrationName, clientConfigurationProperties, oAuth2AccessTokenService)
+	}
+
+	@Bean
+	fun amtPersonAADHttpClient(
+		clientConfigurationProperties: ClientConfigurationProperties,
+		oAuth2AccessTokenService: OAuth2AccessTokenService,
+	): OkHttpClient {
+		val registrationName = "amt-person-aad"
+		return buildClient(registrationName, clientConfigurationProperties, oAuth2AccessTokenService)
 	}
 
 	@Bean
@@ -72,6 +57,22 @@ class HttpClientConfig {
 			.connectTimeout(5, TimeUnit.SECONDS)
 			.readTimeout(5, TimeUnit.SECONDS)
 			.followRedirects(false)
+			.build()
+	}
+
+	private fun buildClient(
+		registrationName: String,
+		clientConfigurationProperties: ClientConfigurationProperties,
+		oAuth2AccessTokenService: OAuth2AccessTokenService,
+	): OkHttpClient {
+		val clientProperties =
+			clientConfigurationProperties.registration[registrationName]
+				?: error("Fant ikke config for $registrationName")
+		return OkHttpClient.Builder()
+			.connectTimeout(5, TimeUnit.SECONDS)
+			.readTimeout(5, TimeUnit.SECONDS)
+			.followRedirects(false)
+			.addInterceptor(bearerTokenInterceptor(clientProperties, oAuth2AccessTokenService))
 			.build()
 	}
 

--- a/src/main/kotlin/no/nav/tiltaksarrangor/ingest/IngestService.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/ingest/IngestService.kt
@@ -103,7 +103,7 @@ class IngestService(
 
 	fun lagreNavAnsatt(id: UUID, navAnsatt: NavAnsatt) {
 		navAnsattRepository.upsert(navAnsatt)
-		log.info("Lagret ansatt med id $id")
+		log.info("Lagret nav-ansatt med id $id")
 	}
 
 	fun lagreEndringsmelding(endringsmeldingId: UUID, endringsmeldingDto: EndringsmeldingDto?) {

--- a/src/main/kotlin/no/nav/tiltaksarrangor/ingest/IngestService.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/ingest/IngestService.kt
@@ -9,6 +9,7 @@ import no.nav.tiltaksarrangor.ingest.model.DeltakerDto
 import no.nav.tiltaksarrangor.ingest.model.DeltakerStatus
 import no.nav.tiltaksarrangor.ingest.model.DeltakerlisteDto
 import no.nav.tiltaksarrangor.ingest.model.EndringsmeldingDto
+import no.nav.tiltaksarrangor.ingest.model.NavAnsatt
 import no.nav.tiltaksarrangor.ingest.model.SKJULES_ALLTID_STATUSER
 import no.nav.tiltaksarrangor.ingest.model.toAnsattDbo
 import no.nav.tiltaksarrangor.ingest.model.toArrangorDbo
@@ -19,6 +20,7 @@ import no.nav.tiltaksarrangor.repositories.ArrangorRepository
 import no.nav.tiltaksarrangor.repositories.DeltakerRepository
 import no.nav.tiltaksarrangor.repositories.DeltakerlisteRepository
 import no.nav.tiltaksarrangor.repositories.EndringsmeldingRepository
+import no.nav.tiltaksarrangor.repositories.NavAnsattRepository
 import no.nav.tiltaksarrangor.repositories.model.DAGER_AVSLUTTET_DELTAKER_VISES
 import no.nav.tiltaksarrangor.repositories.model.DeltakerDbo
 import no.nav.tiltaksarrangor.repositories.model.DeltakerlisteDbo
@@ -38,6 +40,7 @@ class IngestService(
 	private val endringsmeldingRepository: EndringsmeldingRepository,
 	private val amtArrangorClient: AmtArrangorClient,
 	private val unleashService: UnleashService,
+	private val navAnsattRepository: NavAnsattRepository,
 ) {
 	private val log = LoggerFactory.getLogger(javaClass)
 
@@ -96,6 +99,11 @@ class IngestService(
 				log.info("Ignorert deltaker med id $deltakerId")
 			}
 		}
+	}
+
+	fun lagreNavAnsatt(id: UUID, navAnsatt: NavAnsatt) {
+		navAnsattRepository.upsert(navAnsatt)
+		log.info("Lagret ansatt med id $id")
 	}
 
 	fun lagreEndringsmelding(endringsmeldingId: UUID, endringsmeldingDto: EndringsmeldingDto?) {

--- a/src/main/kotlin/no/nav/tiltaksarrangor/ingest/KafkaListener.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/ingest/KafkaListener.kt
@@ -12,13 +12,14 @@ const val ARRANGOR_ANSATT_TOPIC = "amt.arrangor-ansatt-v1"
 const val DELTAKERLISTE_TOPIC = "team-mulighetsrommet.siste-tiltaksgjennomforinger-v1"
 const val DELTAKER_TOPIC = "amt.deltaker-v2"
 const val ENDRINGSMELDING_TOPIC = "amt.endringsmelding-v1"
+const val NAV_ANSATT_TOPIC = "amt.nav-ansatt-personalia-v1"
 
 @Component
 class KafkaListener(
 	val ingestService: IngestService,
 ) {
 	@KafkaListener(
-		topics = [ARRANGOR_TOPIC, ARRANGOR_ANSATT_TOPIC, DELTAKERLISTE_TOPIC, DELTAKER_TOPIC, ENDRINGSMELDING_TOPIC],
+		topics = [ARRANGOR_TOPIC, ARRANGOR_ANSATT_TOPIC, DELTAKERLISTE_TOPIC, DELTAKER_TOPIC, ENDRINGSMELDING_TOPIC, NAV_ANSATT_TOPIC],
 		properties = ["auto.offset.reset = earliest"],
 		containerFactory = "kafkaListenerContainerFactory",
 	)
@@ -29,6 +30,7 @@ class KafkaListener(
 			DELTAKERLISTE_TOPIC -> ingestService.lagreDeltakerliste(UUID.fromString(cr.key()), cr.value()?.let { fromJsonString(it) })
 			DELTAKER_TOPIC -> ingestService.lagreDeltaker(UUID.fromString(cr.key()), cr.value()?.let { fromJsonString(it) })
 			ENDRINGSMELDING_TOPIC -> ingestService.lagreEndringsmelding(UUID.fromString(cr.key()), cr.value()?.let { fromJsonString(it) })
+			NAV_ANSATT_TOPIC -> ingestService.lagreNavAnsatt(UUID.fromString(cr.key()), fromJsonString(cr.value()))
 			else -> throw IllegalStateException("Mottok melding på ukjent topic: ${cr.topic()}")
 		}
 		acknowledgment.acknowledge()

--- a/src/main/kotlin/no/nav/tiltaksarrangor/ingest/model/NavAnsatt.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/ingest/model/NavAnsatt.kt
@@ -1,0 +1,11 @@
+package no.nav.tiltaksarrangor.ingest.model
+
+import java.util.UUID
+
+data class NavAnsatt(
+	val id: UUID,
+	val navident: String,
+	val navn: String,
+	val epost: String?,
+	val telefon: String?,
+)

--- a/src/main/kotlin/no/nav/tiltaksarrangor/ingest/model/NavEnhet.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/ingest/model/NavEnhet.kt
@@ -1,0 +1,9 @@
+package no.nav.tiltaksarrangor.ingest.model
+
+import java.util.UUID
+
+data class NavEnhet(
+	val id: UUID,
+	val enhetId: String,
+	val navn: String,
+)

--- a/src/main/kotlin/no/nav/tiltaksarrangor/melding/forslag/ForslagController.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/melding/forslag/ForslagController.kt
@@ -31,7 +31,7 @@ class ForslagController(
 	fun forleng(
 		@PathVariable deltakerId: UUID,
 		@RequestBody request: ForlengDeltakelseRequest,
-	) {
+	): AktivtForslagResponse {
 		val personident = tokenService.getPersonligIdentTilInnloggetAnsatt()
 		val ansatt = ansattService.getAnsattMedRoller(personident)
 		val deltakerMedDeltakerliste =
@@ -44,10 +44,12 @@ class ForslagController(
 
 		tilgangskontrollService.verifiserTilgangTilDeltakerOgMeldinger(ansatt, deltakerMedDeltakerliste)
 
-		forslagService.opprettForslag(
+		val forslag = forslagService.opprettForslag(
 			request,
 			ansatt,
 			deltakerMedDeltakerliste,
 		)
+
+		return forslag.tilAktivtForslagResponse()
 	}
 }

--- a/src/main/kotlin/no/nav/tiltaksarrangor/melding/forslag/ForslagRepository.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/melding/forslag/ForslagRepository.kt
@@ -63,6 +63,12 @@ class ForslagRepository(
 		return template.queryForObject(sql, params, rowMapper)
 			?: throw NoSuchElementException("Noe gikk galt med upsert av forslag ${forslag.id}")
 	}
+
+	fun getForDeltaker(deltakerId: UUID): List<Forslag> {
+		val sql = "select * from forslag where deltaker_id = :deltaker_id"
+		val params = sqlParameters("deltaker_id" to deltakerId)
+		return template.query(sql, params, rowMapper)
+	}
 }
 
 fun toPGObject(value: Any?) = PGobject().also {

--- a/src/main/kotlin/no/nav/tiltaksarrangor/melding/forslag/ForslagResponse.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/melding/forslag/ForslagResponse.kt
@@ -50,7 +50,7 @@ data class AktivtForslagResponse(
 
 fun Forslag.tilAktivtForslagResponse(): AktivtForslagResponse {
 	require(this.status is Forslag.Status.VenterPaSvar) {
-		"Forslag ${this.id} kan ikke mappes til VenterPaSvarForslagResponse"
+		"Forslag ${this.id} kan ikke mappes til AktivtForslagResponse pga feil status"
 	}
 	return AktivtForslagResponse(
 		this.id,

--- a/src/main/kotlin/no/nav/tiltaksarrangor/melding/forslag/ForslagResponse.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/melding/forslag/ForslagResponse.kt
@@ -1,0 +1,61 @@
+package no.nav.tiltaksarrangor.melding.forslag
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import no.nav.amt.lib.models.arrangor.melding.Forslag
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class ForslagResponse(
+	val id: UUID,
+	val opprettetAvArrangor: String,
+	val opprettet: LocalDateTime,
+	val begrunnelse: String,
+	val endring: Forslag.Endring,
+	val status: Status,
+) {
+	@JsonTypeInfo(use = JsonTypeInfo.Id.SIMPLE_NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+	sealed interface Status {
+		data class Godkjent(
+			val godkjentAv: NavAnsatt,
+			val godkjent: LocalDateTime,
+		) : Status
+
+		data class Avvist(
+			val avvistAv: NavAnsatt,
+			val avvist: LocalDateTime,
+			val begrunnelseFraNav: String,
+		) : Status
+
+		data class Tilbakekalt(
+			val tilbakekaltAvArrangor: String,
+			val tilbakekalt: LocalDateTime,
+		) : Status
+
+		data object VenterPaSvar : Status
+	}
+
+	data class NavAnsatt(
+		val navn: String,
+		val enhet: String,
+	)
+}
+
+data class AktivtForslagResponse(
+	val id: UUID,
+	val opprettet: LocalDateTime,
+	val begrunnelse: String,
+	val endring: Forslag.Endring,
+	val status: ForslagResponse.Status.VenterPaSvar = ForslagResponse.Status.VenterPaSvar,
+)
+
+fun Forslag.tilAktivtForslagResponse(): AktivtForslagResponse {
+	require(this.status is Forslag.Status.VenterPaSvar) {
+		"Forslag ${this.id} kan ikke mappes til VenterPaSvarForslagResponse"
+	}
+	return AktivtForslagResponse(
+		this.id,
+		this.opprettet,
+		this.begrunnelse,
+		this.endring,
+	)
+}

--- a/src/main/kotlin/no/nav/tiltaksarrangor/melding/forslag/ForslagService.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/melding/forslag/ForslagService.kt
@@ -44,4 +44,6 @@ class ForslagService(
 
 		return forslag
 	}
+
+	fun getAktiveForslag(deltakerId: UUID) = repository.getForDeltaker(deltakerId).filter { it.status is Forslag.Status.VenterPaSvar }
 }

--- a/src/main/kotlin/no/nav/tiltaksarrangor/model/Deltaker.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/model/Deltaker.kt
@@ -1,5 +1,6 @@
 package no.nav.tiltaksarrangor.model
 
+import no.nav.tiltaksarrangor.melding.forslag.AktivtForslagResponse
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
@@ -25,6 +26,7 @@ data class Deltaker(
 	val fjernesDato: LocalDateTime?,
 	val navInformasjon: NavInformasjon,
 	val veiledere: List<Veileder>,
+	val aktiveForslag: List<AktivtForslagResponse>,
 	val aktiveEndringsmeldinger: List<Endringsmelding>,
 	val historiskeEndringsmeldinger: List<Endringsmelding>,
 	val adresse: Adresse?,

--- a/src/main/kotlin/no/nav/tiltaksarrangor/repositories/NavAnsattRepository.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/repositories/NavAnsattRepository.kt
@@ -1,0 +1,64 @@
+package no.nav.tiltaksarrangor.repositories
+
+import no.nav.tiltaksarrangor.ingest.model.NavAnsatt
+import no.nav.tiltaksarrangor.utils.sqlParameters
+import org.springframework.jdbc.core.RowMapper
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class NavAnsattRepository(
+	private val template: NamedParameterJdbcTemplate,
+) {
+	private val rowMapper = RowMapper { rs, _ ->
+		NavAnsatt(
+			id = UUID.fromString(rs.getString("id")),
+			navident = rs.getString("nav_ident"),
+			navn = rs.getString("navn"),
+			epost = rs.getString("epost"),
+			telefon = rs.getString("telefon"),
+		)
+	}
+
+	fun upsert(navAnsatt: NavAnsatt) {
+		val sql =
+			"""
+			insert into nav_ansatt (id,
+									nav_ident,
+									navn,
+									telefon,
+									epost)
+			values (:id,
+					:nav_ident,
+					:navn,
+					:telefon,
+					:epost)
+			on conflict (id) do update set
+				navn = :navn,
+				telefon = :telefon,
+				epost = :epost,
+				modified_at = current_timestamp
+			""".trimIndent()
+		val params = sqlParameters(
+			"id" to navAnsatt.id,
+			"nav_ident" to navAnsatt.navident,
+			"navn" to navAnsatt.navn,
+			"telefon" to navAnsatt.telefon,
+			"epost" to navAnsatt.epost,
+		)
+
+		template.update(sql, params)
+	}
+
+	fun get(id: UUID): NavAnsatt? {
+		val sql =
+			"""
+			select * from nav_ansatt where id = :id
+			""".trimIndent()
+
+		val params = sqlParameters("id" to id)
+
+		return template.query(sql, params, rowMapper).firstOrNull()
+	}
+}

--- a/src/main/kotlin/no/nav/tiltaksarrangor/repositories/NavEnhetRepository.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/repositories/NavEnhetRepository.kt
@@ -1,0 +1,50 @@
+package no.nav.tiltaksarrangor.repositories
+
+import no.nav.tiltaksarrangor.ingest.model.NavEnhet
+import no.nav.tiltaksarrangor.utils.sqlParameters
+import org.springframework.jdbc.core.RowMapper
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class NavEnhetRepository(private val template: NamedParameterJdbcTemplate) {
+	private val rowMapper = RowMapper { rs, _ ->
+		NavEnhet(
+			id = UUID.fromString(rs.getString("id")),
+			enhetId = rs.getString("nav_enhet_nummer"),
+			navn = rs.getString("navn"),
+		)
+	}
+
+	fun upsert(enhet: NavEnhet) {
+		val sql =
+			"""
+			insert into nav_enhet (id, nav_enhet_nummer, navn)
+			values (:id,
+					:nav_enhet_nummer,
+					:navn)
+			on conflict (id) do update set
+				navn = :navn,
+				nav_enhet_nummer = :nav_enhet_nummer,
+				modified_at = current_timestamp
+			""".trimIndent()
+		val params = sqlParameters(
+			"id" to enhet.id,
+			"nav_enhet_nummer" to enhet.enhetId,
+			"navn" to enhet.navn,
+		)
+
+		template.update(sql, params)
+	}
+
+	fun get(id: UUID): NavEnhet? {
+		val sql =
+			"""
+			select * from nav_enhet where id = :id
+			""".trimIndent()
+		val params = sqlParameters("id" to id)
+
+		return template.query(sql, params, rowMapper).firstOrNull()
+	}
+}

--- a/src/main/kotlin/no/nav/tiltaksarrangor/service/NavEnhetService.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/service/NavEnhetService.kt
@@ -1,0 +1,27 @@
+package no.nav.tiltaksarrangor.service
+
+import no.nav.tiltaksarrangor.client.amtperson.AmtPersonClient
+import no.nav.tiltaksarrangor.ingest.model.NavEnhet
+import no.nav.tiltaksarrangor.repositories.NavEnhetRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+class NavEnhetService(
+	private val repository: NavEnhetRepository,
+	private val amtPersonClient: AmtPersonClient,
+) {
+	private val log = LoggerFactory.getLogger(javaClass)
+
+	fun get(id: UUID): NavEnhet = repository.get(id) ?: fetchEnhet(id)
+
+	private fun fetchEnhet(id: UUID): NavEnhet {
+		val enhet = amtPersonClient.hentEnhet(id)
+
+		repository.upsert(enhet)
+		log.info("Lagret nav-enhet $id")
+
+		return enhet
+	}
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,8 +35,16 @@ no.nav.security.jwt.client.registration.amt-arrangor-aad.authentication.client-i
 no.nav.security.jwt.client.registration.amt-arrangor-aad.authentication.client-secret=${AZURE_APP_CLIENT_SECRET}
 no.nav.security.jwt.client.registration.amt-arrangor-aad.authentication.client-auth-method=client_secret_basic
 
+no.nav.security.jwt.client.registration.amt-person-aad.token-endpoint-url=${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+no.nav.security.jwt.client.registration.amt-person-aad.grant-type=client_credentials
+no.nav.security.jwt.client.registration.amt-person-aad.scope=${AMT_PERSON_AAD_CLIENT_ID}
+no.nav.security.jwt.client.registration.amt-person-aad.authentication.client-id=${AZURE_APP_CLIENT_ID}
+no.nav.security.jwt.client.registration.amt-person-aad.authentication.client-secret=${AZURE_APP_CLIENT_SECRET}
+no.nav.security.jwt.client.registration.amt-person-aad.authentication.client-auth-method=client_secret_basic
+
 amt-tiltak.url=http://amt-tiltak
 amt-arrangor.url=http://amt-arrangor
+amt-person.url=http://amt-person-service
 
 app.env.unleashUrl=${UNLEASH_SERVER_API_URL}/api
 app.env.unleashApiToken=${UNLEASH_SERVER_API_TOKEN}

--- a/src/main/resources/db/migration/V19__nav-ansatt-og-enhet.sql
+++ b/src/main/resources/db/migration/V19__nav-ansatt-og-enhet.sql
@@ -1,0 +1,21 @@
+CREATE TABLE nav_ansatt
+(
+    id          uuid primary key,
+    nav_ident   varchar                  not null,
+    navn        varchar                  not null,
+    telefon     varchar,
+    epost       varchar,
+    created_at  timestamp with time zone not null default current_timestamp,
+    modified_at timestamp with time zone not null default current_timestamp,
+    unique (nav_ident)
+);
+
+create table nav_enhet
+(
+    id               uuid primary key,
+    nav_enhet_nummer varchar                  not null,
+    navn             varchar                  not null,
+    created_at       timestamp with time zone not null default current_timestamp,
+    modified_at      timestamp with time zone not null default current_timestamp,
+    unique (nav_enhet_nummer)
+);

--- a/src/test/kotlin/no/nav/tiltaksarrangor/IntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tiltaksarrangor/IntegrationTest.kt
@@ -6,6 +6,7 @@ import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
 import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
 import no.nav.tiltaksarrangor.mock.MockAmtArrangorHttpServer
+import no.nav.tiltaksarrangor.mock.MockAmtPersonHttpServer
 import no.nav.tiltaksarrangor.mock.MockAmtTiltakHttpServer
 import no.nav.tiltaksarrangor.testutils.DbTestDataUtils
 import no.nav.tiltaksarrangor.testutils.SingletonPostgresContainer
@@ -59,6 +60,7 @@ class IntegrationTest {
 	companion object {
 		val mockAmtTiltakServer = MockAmtTiltakHttpServer()
 		val mockAmtArrangorServer = MockAmtArrangorHttpServer()
+		val mockAmtPersonServer = MockAmtPersonHttpServer()
 		val postgresDataSource = SingletonPostgresContainer.getDataSource()
 
 		@JvmStatic
@@ -68,6 +70,8 @@ class IntegrationTest {
 			registry.add("amt-tiltak.url", mockAmtTiltakServer::serverUrl)
 			mockAmtArrangorServer.start()
 			registry.add("amt-arrangor.url", mockAmtArrangorServer::serverUrl)
+			mockAmtPersonServer.start()
+			registry.add("amt-person.url", mockAmtPersonServer::serverUrl)
 
 			val container = SingletonPostgresContainer.getContainer()
 

--- a/src/test/kotlin/no/nav/tiltaksarrangor/controller/TiltaksarrangorControllerTest.kt
+++ b/src/test/kotlin/no/nav/tiltaksarrangor/controller/TiltaksarrangorControllerTest.kt
@@ -8,6 +8,7 @@ import no.nav.tiltaksarrangor.ingest.model.AnsattRolle
 import no.nav.tiltaksarrangor.ingest.model.EndringsmeldingType
 import no.nav.tiltaksarrangor.ingest.model.Innhold
 import no.nav.tiltaksarrangor.ingest.model.VurderingDto
+import no.nav.tiltaksarrangor.melding.forslag.ForslagRepository
 import no.nav.tiltaksarrangor.model.DeltakerStatusAarsak
 import no.nav.tiltaksarrangor.model.Endringsmelding
 import no.nav.tiltaksarrangor.model.StatusType
@@ -44,6 +45,7 @@ class TiltaksarrangorControllerTest : IntegrationTest() {
 	private val deltakerlisteRepository = DeltakerlisteRepository(template, deltakerRepository)
 	private val endringsmeldingRepository = EndringsmeldingRepository(template)
 	private val arrangorRepository = ArrangorRepository(template)
+	private val forslagRepository = ForslagRepository(template)
 
 	@AfterEach
 	internal fun tearDown() {
@@ -213,9 +215,11 @@ class TiltaksarrangorControllerTest : IntegrationTest() {
 
 		val expectedJson =
 			"""
-			{"id":"977350f2-d6a5-49bb-a3a0-773f25f863d9","deltakerliste":{"id":"9987432c-e336-4b3b-b73e-b7c781a0823a","startDato":"2023-02-01","sluttDato":null,"erKurs":false},"fornavn":"Fornavn","mellomnavn":null,"etternavn":"Etternavn","fodselsnummer":"10987654321","telefonnummer":"90909090","epost":"mail@test.no","status":{"type":"DELTAR","endretDato":"2023-02-01T00:00:00"},"startDato":"2023-02-01","sluttDato":null,"deltakelseProsent":null,"dagerPerUke":2.5,"soktInnPa":"Gjennomføring 1","soktInnDato":"2023-01-15T00:00:00","tiltakskode":"ARBFORB","bestillingTekst":"Tror deltakeren vil ha nytte av dette","fjernesDato":null,"navInformasjon":{"navkontor":"Nav Oslo","navVeileder":{"navn":"Veileder Veiledersen","epost":"epost@nav.no","telefon":"56565656"}},"veiledere":[{"ansattId":"2d5fc2f7-a9e6-4830-a987-4ff135a70c10","deltakerId":"977350f2-d6a5-49bb-a3a0-773f25f863d9","veiledertype":"VEILEDER","fornavn":"Fornavn","mellomnavn":null,"etternavn":"Etternavn"},{"ansattId":"7c43b43b-43be-4d4b-8057-d907c5f1e5c5","deltakerId":"977350f2-d6a5-49bb-a3a0-773f25f863d9","veiledertype":"MEDVEILEDER","fornavn":"Per","mellomnavn":null,"etternavn":"Person"}],"aktiveEndringsmeldinger":[{"id":"27446cc8-30ad-4030-94e3-de438c2af3c6","innhold":{"sluttdato":"2023-03-30","aarsak":{"type":"SYK","beskrivelse":"har blitt syk"}},"type":"AVSLUTT_DELTAKELSE","status":"AKTIV","sendt":"2023-03-30"},{"id":"362c7fdd-04e7-4f43-9e56-0939585856eb","innhold":{"sluttdato":"2023-05-03"},"type":"ENDRE_SLUTTDATO","status":"AKTIV","sendt":"2023-04-03"}],"historiskeEndringsmeldinger":[{"id":"ab4d67a5-2556-4f63-b27a-ced04a231d0e","innhold":{"oppstartsdato":"2022-05-03"},"type":"LEGG_TIL_OPPSTARTSDATO","status":"UTFORT","sendt":"2022-01-01"}],"adresse":{"adressetype":"KONTAKTADRESSE","postnummer":"1234","poststed":"MOSS","tilleggsnavn":null,"adressenavn":"Gate 1"},"gjeldendeVurderingFraArrangor":{"vurderingstype":"OPPFYLLER_IKKE_KRAVENE","begrunnelse":"Mangler førerkort","gyldigFra":${objectMapper.writeValueAsString(
-				gyldigFra,
-			)},"gyldigTil":null},"historiskeVurderingerFraArrangor":[],"adressebeskyttet":false}
+			{"id":"977350f2-d6a5-49bb-a3a0-773f25f863d9","deltakerliste":{"id":"9987432c-e336-4b3b-b73e-b7c781a0823a","startDato":"2023-02-01","sluttDato":null,"erKurs":false},"fornavn":"Fornavn","mellomnavn":null,"etternavn":"Etternavn","fodselsnummer":"10987654321","telefonnummer":"90909090","epost":"mail@test.no","status":{"type":"DELTAR","endretDato":"2023-02-01T00:00:00"},"startDato":"2023-02-01","sluttDato":null,"deltakelseProsent":null,"dagerPerUke":2.5,"soktInnPa":"Gjennomføring 1","soktInnDato":"2023-01-15T00:00:00","tiltakskode":"ARBFORB","bestillingTekst":"Tror deltakeren vil ha nytte av dette","fjernesDato":null,"navInformasjon":{"navkontor":"Nav Oslo","navVeileder":{"navn":"Veileder Veiledersen","epost":"epost@nav.no","telefon":"56565656"}},"veiledere":[{"ansattId":"2d5fc2f7-a9e6-4830-a987-4ff135a70c10","deltakerId":"977350f2-d6a5-49bb-a3a0-773f25f863d9","veiledertype":"VEILEDER","fornavn":"Fornavn","mellomnavn":null,"etternavn":"Etternavn"},{"ansattId":"7c43b43b-43be-4d4b-8057-d907c5f1e5c5","deltakerId":"977350f2-d6a5-49bb-a3a0-773f25f863d9","veiledertype":"MEDVEILEDER","fornavn":"Per","mellomnavn":null,"etternavn":"Person"}],"aktiveForslag":[],"aktiveEndringsmeldinger":[{"id":"27446cc8-30ad-4030-94e3-de438c2af3c6","innhold":{"sluttdato":"2023-03-30","aarsak":{"type":"SYK","beskrivelse":"har blitt syk"}},"type":"AVSLUTT_DELTAKELSE","status":"AKTIV","sendt":"2023-03-30"},{"id":"362c7fdd-04e7-4f43-9e56-0939585856eb","innhold":{"sluttdato":"2023-05-03"},"type":"ENDRE_SLUTTDATO","status":"AKTIV","sendt":"2023-04-03"}],"historiskeEndringsmeldinger":[{"id":"ab4d67a5-2556-4f63-b27a-ced04a231d0e","innhold":{"oppstartsdato":"2022-05-03"},"type":"LEGG_TIL_OPPSTARTSDATO","status":"UTFORT","sendt":"2022-01-01"}],"adresse":{"adressetype":"KONTAKTADRESSE","postnummer":"1234","poststed":"MOSS","tilleggsnavn":null,"adressenavn":"Gate 1"},"gjeldendeVurderingFraArrangor":{"vurderingstype":"OPPFYLLER_IKKE_KRAVENE","begrunnelse":"Mangler førerkort","gyldigFra":${
+				objectMapper.writeValueAsString(
+					gyldigFra,
+				)
+			},"gyldigTil":null},"historiskeVurderingerFraArrangor":[],"adressebeskyttet":false}
 			""".trimIndent()
 		response.code shouldBe 200
 		response.body?.string() shouldBe expectedJson

--- a/src/test/kotlin/no/nav/tiltaksarrangor/ingest/IngestServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltaksarrangor/ingest/IngestServiceTest.kt
@@ -28,8 +28,10 @@ import no.nav.tiltaksarrangor.repositories.ArrangorRepository
 import no.nav.tiltaksarrangor.repositories.DeltakerRepository
 import no.nav.tiltaksarrangor.repositories.DeltakerlisteRepository
 import no.nav.tiltaksarrangor.repositories.EndringsmeldingRepository
+import no.nav.tiltaksarrangor.repositories.NavAnsattRepository
 import no.nav.tiltaksarrangor.testutils.getAdresse
 import no.nav.tiltaksarrangor.testutils.getDeltaker
+import no.nav.tiltaksarrangor.testutils.getNavAnsatt
 import no.nav.tiltaksarrangor.testutils.getVurderinger
 import no.nav.tiltaksarrangor.unleash.UnleashService
 import org.junit.jupiter.api.BeforeEach
@@ -46,6 +48,7 @@ class IngestServiceTest {
 	private val endringsmeldingRepository = mockk<EndringsmeldingRepository>()
 	private val amtArrangorClient = mockk<AmtArrangorClient>()
 	private val unleashService = mockk<UnleashService>()
+	private val navAnsattRepository = mockk<NavAnsattRepository>(relaxUnitFun = true)
 	private val ingestService =
 		IngestService(
 			arrangorRepository,
@@ -55,6 +58,7 @@ class IngestServiceTest {
 			endringsmeldingRepository,
 			amtArrangorClient,
 			unleashService,
+			navAnsattRepository,
 		)
 
 	private val arrangor =
@@ -793,5 +797,14 @@ class IngestServiceTest {
 		ingestService.lagreEndringsmelding(endringsmeldingId, endringsmeldingDto)
 
 		verify(exactly = 1) { endringsmeldingRepository.insertOrUpdateEndringsmelding(any()) }
+	}
+
+	@Test
+	internal fun `lagreNavAnsatt - ny ansatt - lagres`() {
+		val navAnsatt = getNavAnsatt()
+
+		ingestService.lagreNavAnsatt(navAnsatt.id, navAnsatt)
+
+		verify(exactly = 1) { navAnsattRepository.upsert(navAnsatt) }
 	}
 }

--- a/src/test/kotlin/no/nav/tiltaksarrangor/melding/forslag/ForslagServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltaksarrangor/melding/forslag/ForslagServiceTest.kt
@@ -40,4 +40,16 @@ class ForslagServiceTest {
 			assertProducedForslag(opprettetForslag.id, opprettetForslag.endring::class)
 		}
 	}
+
+	@Test
+	fun `getAktiveForslag - filtrerer bort forslag uten riktig status`() {
+		with(ForslagCtx(forlengDeltakelseForslag())) {
+			upsertForslag()
+			medInaktiveForslag()
+
+			val aktiveForslag = forslagService.getAktiveForslag(deltaker.id)
+			aktiveForslag.size shouldBe 1
+			aktiveForslag.first().status shouldBe Forslag.Status.VenterPaSvar
+		}
+	}
 }

--- a/src/test/kotlin/no/nav/tiltaksarrangor/melding/forslag/ForslagUtils.kt
+++ b/src/test/kotlin/no/nav/tiltaksarrangor/melding/forslag/ForslagUtils.kt
@@ -4,25 +4,30 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import no.nav.amt.lib.models.arrangor.melding.Forslag
 import no.nav.amt.lib.testing.AsyncUtils
+import no.nav.tiltaksarrangor.ingest.model.NavAnsatt
 import no.nav.tiltaksarrangor.kafka.stringStringConsumer
 import no.nav.tiltaksarrangor.melding.MELDING_TOPIC
+import no.nav.tiltaksarrangor.repositories.NavAnsattRepository
 import no.nav.tiltaksarrangor.repositories.model.AnsattDbo
 import no.nav.tiltaksarrangor.repositories.model.ArrangorDbo
 import no.nav.tiltaksarrangor.repositories.model.DeltakerDbo
 import no.nav.tiltaksarrangor.repositories.model.DeltakerlisteDbo
 import no.nav.tiltaksarrangor.testutils.DeltakerContext
+import no.nav.tiltaksarrangor.testutils.SingletonPostgresContainer
 import no.nav.tiltaksarrangor.testutils.getArrangor
 import no.nav.tiltaksarrangor.testutils.getDeltaker
 import no.nav.tiltaksarrangor.testutils.getDeltakerliste
 import no.nav.tiltaksarrangor.testutils.getKoordinator
+import no.nav.tiltaksarrangor.testutils.getNavAnsatt
 import no.nav.tiltaksarrangor.utils.JsonUtils.objectMapper
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
 import kotlin.reflect.KClass
 
 class ForslagCtx(
-	val forslag: Forslag,
+	var forslag: Forslag,
 	arrangor: ArrangorDbo = getArrangor(),
 	deltakerliste: DeltakerlisteDbo = getDeltakerliste(arrangorId = arrangor.id),
 	koordinator: AnsattDbo = getKoordinator(
@@ -36,16 +41,59 @@ class ForslagCtx(
 		deltakerliste = deltakerliste,
 		koordinator = koordinator,
 		deltaker = deltaker,
-	)
+	) {
+	var navAnsatt: NavAnsatt? = null
 
-fun forlengDeltakelseForslag(sluttdato: LocalDate = LocalDate.now(), begrunnelse: String = "Fordi...") = Forslag(
+	private val template = NamedParameterJdbcTemplate(SingletonPostgresContainer.getDataSource())
+	private val navAnsattRepository = NavAnsattRepository(template)
+	private val forslagRepository = ForslagRepository(template)
+
+	init {
+		opprettNavAnsattForForslag()
+	}
+
+	fun setForslagGodkjent() {
+		val status = Forslag.Status.Godkjent(
+			Forslag.NavAnsatt(UUID.randomUUID(), UUID.randomUUID()),
+			LocalDateTime.now(),
+		)
+
+		forslag = forslag.copy(status = status)
+		opprettNavAnsattForForslag()
+	}
+
+	fun upsertForslag() = forslagRepository.upsert(forslag)
+
+	private fun opprettNavAnsattForForslag() {
+		val forslagNavAnsatt = when (val status = forslag.status) {
+			is Forslag.Status.Avvist -> status.avvistAv
+			is Forslag.Status.Godkjent -> status.godkjentAv
+			is Forslag.Status.Tilbakekalt -> null
+			Forslag.Status.VenterPaSvar -> null
+		}
+
+		navAnsatt = if (forslagNavAnsatt != null) {
+			getNavAnsatt(id = forslagNavAnsatt.id)
+		} else {
+			null
+		}
+
+		navAnsatt?.let { navAnsattRepository.upsert(it) }
+	}
+}
+
+fun forlengDeltakelseForslag(
+	sluttdato: LocalDate = LocalDate.now(),
+	begrunnelse: String = "Fordi...",
+	status: Forslag.Status = Forslag.Status.VenterPaSvar,
+) = Forslag(
 	id = UUID.randomUUID(),
 	deltakerId = UUID.randomUUID(),
 	opprettetAvArrangorAnsattId = UUID.randomUUID(),
 	opprettet = LocalDateTime.now(),
 	begrunnelse = begrunnelse,
 	endring = Forslag.ForlengDeltakelse(sluttdato),
-	status = Forslag.Status.VenterPaSvar,
+	status = status,
 )
 
 fun <T : Forslag.Endring> assertProducedForslag(forslagId: UUID, endringstype: KClass<T>) {

--- a/src/test/kotlin/no/nav/tiltaksarrangor/melding/forslag/ForslagUtils.kt
+++ b/src/test/kotlin/no/nav/tiltaksarrangor/melding/forslag/ForslagUtils.kt
@@ -68,6 +68,38 @@ class ForslagCtx(
 		opprettNavAnsattForForslag()
 	}
 
+	fun medInaktiveForslag() {
+		leggTilForslagMedStatus(
+			Forslag.Status.Tilbakekalt(
+				UUID.randomUUID(),
+				LocalDateTime.now(),
+			),
+		)
+		leggTilForslagMedStatus(
+			Forslag.Status.Godkjent(
+				Forslag.NavAnsatt(UUID.randomUUID(), UUID.randomUUID()),
+				LocalDateTime.now(),
+			),
+		)
+		leggTilForslagMedStatus(
+			Forslag.Status.Avvist(
+				Forslag.NavAnsatt(UUID.randomUUID(), UUID.randomUUID()),
+				LocalDateTime.now(),
+				"Avvist!",
+			),
+		)
+	}
+
+	fun leggTilForslagMedStatus(status: Forslag.Status) {
+		forslagRepository.upsert(
+			forlengDeltakelseForslag(
+				deltakerId = deltaker.id,
+				opprettetAvArrangorAnsattId = koordinator.id,
+				status = status,
+			),
+		)
+	}
+
 	fun upsertForslag() = forslagRepository.upsert(forslag)
 
 	private fun opprettNavAnsattForForslag() {
@@ -91,13 +123,15 @@ class ForslagCtx(
 }
 
 fun forlengDeltakelseForslag(
+	deltakerId: UUID = UUID.randomUUID(),
+	opprettetAvArrangorAnsattId: UUID = UUID.randomUUID(),
 	sluttdato: LocalDate = LocalDate.now(),
 	begrunnelse: String = "Fordi...",
 	status: Forslag.Status = Forslag.Status.VenterPaSvar,
 ) = Forslag(
 	id = UUID.randomUUID(),
-	deltakerId = UUID.randomUUID(),
-	opprettetAvArrangorAnsattId = UUID.randomUUID(),
+	deltakerId = deltakerId,
+	opprettetAvArrangorAnsattId = opprettetAvArrangorAnsattId,
 	opprettet = LocalDateTime.now(),
 	begrunnelse = begrunnelse,
 	endring = Forslag.ForlengDeltakelse(sluttdato),

--- a/src/test/kotlin/no/nav/tiltaksarrangor/mock/MockAmtPersonHttpServer.kt
+++ b/src/test/kotlin/no/nav/tiltaksarrangor/mock/MockAmtPersonHttpServer.kt
@@ -1,0 +1,17 @@
+package no.nav.tiltaksarrangor.mock
+
+import no.nav.tiltaksarrangor.testutils.getNavEnhet
+import no.nav.tiltaksarrangor.utils.JsonUtils
+import okhttp3.mockwebserver.MockResponse
+import java.util.UUID
+
+class MockAmtPersonHttpServer : MockHttpServer(name = "amt-person-server") {
+	fun addEnhetResponse(id: UUID = UUID.randomUUID()) {
+		addResponseHandler(
+			path = "/api/nav-enhet/$id",
+			MockResponse()
+				.setResponseCode(200)
+				.setBody(JsonUtils.objectMapper.writeValueAsString(getNavEnhet(id))),
+		)
+	}
+}

--- a/src/test/kotlin/no/nav/tiltaksarrangor/repositories/NavAnsattRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tiltaksarrangor/repositories/NavAnsattRepositoryTest.kt
@@ -1,0 +1,32 @@
+package no.nav.tiltaksarrangor.repositories
+
+import io.kotest.matchers.shouldBe
+import no.nav.tiltaksarrangor.testutils.SingletonPostgresContainer
+import no.nav.tiltaksarrangor.testutils.getNavAnsatt
+import org.junit.jupiter.api.Test
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+
+class NavAnsattRepositoryTest {
+	private val dataSource = SingletonPostgresContainer.getDataSource()
+	private val template = NamedParameterJdbcTemplate(dataSource)
+	private val repository = NavAnsattRepository(template)
+
+	@Test
+	fun `upsert - ny ansatt - inserter`() {
+		val ansatt = getNavAnsatt()
+		repository.upsert(ansatt)
+		val insertedAnsatt = repository.get(ansatt.id)
+		insertedAnsatt shouldBe ansatt
+	}
+
+	@Test
+	fun `upsert - endret ansatt - oppdaterer`() {
+		val ansatt = getNavAnsatt()
+		repository.upsert(ansatt)
+		val nyEpost = "foo@bar.baz"
+		repository.upsert(ansatt.copy(epost = "foo@bar.baz"))
+
+		val insertedAnsatt = repository.get(ansatt.id)
+		insertedAnsatt!!.epost shouldBe nyEpost
+	}
+}

--- a/src/test/kotlin/no/nav/tiltaksarrangor/repositories/NavEnhetRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tiltaksarrangor/repositories/NavEnhetRepositoryTest.kt
@@ -1,0 +1,31 @@
+package no.nav.tiltaksarrangor.repositories
+
+import io.kotest.matchers.shouldBe
+import no.nav.tiltaksarrangor.testutils.SingletonPostgresContainer
+import no.nav.tiltaksarrangor.testutils.getNavEnhet
+import org.junit.jupiter.api.Test
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+
+class NavEnhetRepositoryTest {
+	private val repository = NavEnhetRepository(NamedParameterJdbcTemplate(SingletonPostgresContainer.getDataSource()))
+
+	@Test
+	fun `upsert - ny enhet - inserter`() {
+		val enhet = getNavEnhet()
+		repository.upsert(enhet)
+
+		val insertedEnhet = repository.get(enhet.id)
+		insertedEnhet shouldBe enhet
+	}
+
+	@Test
+	fun `upsert - endret enhet - oppdaterer`() {
+		val enhet = getNavEnhet()
+		repository.upsert(enhet)
+
+		val navn = "Nytt Navn"
+		repository.upsert(enhet.copy(navn = navn))
+
+		repository.get(enhet.id)!!.navn shouldBe navn
+	}
+}

--- a/src/test/kotlin/no/nav/tiltaksarrangor/service/TiltaksarrangorServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltaksarrangor/service/TiltaksarrangorServiceTest.kt
@@ -19,6 +19,9 @@ import no.nav.tiltaksarrangor.ingest.model.Oppholdsadresse
 import no.nav.tiltaksarrangor.ingest.model.Postboksadresse
 import no.nav.tiltaksarrangor.ingest.model.Vegadresse
 import no.nav.tiltaksarrangor.ingest.model.VurderingDto
+import no.nav.tiltaksarrangor.melding.MeldingProducer
+import no.nav.tiltaksarrangor.melding.forslag.ForslagRepository
+import no.nav.tiltaksarrangor.melding.forslag.ForslagService
 import no.nav.tiltaksarrangor.model.Adressetype
 import no.nav.tiltaksarrangor.model.Endringsmelding
 import no.nav.tiltaksarrangor.model.StatusType
@@ -61,6 +64,9 @@ class TiltaksarrangorServiceTest {
 	private val deltakerRepository = DeltakerRepository(template)
 	private val deltakerlisteRepository = DeltakerlisteRepository(template, deltakerRepository)
 	private val endringsmeldingRepository = EndringsmeldingRepository(template)
+	private val forslagRepository = ForslagRepository(template)
+	private val meldingProducer = mockk<MeldingProducer>(relaxUnitFun = true)
+	private val forslagService = ForslagService(forslagRepository, meldingProducer)
 	private val tilgangskontrollService = TilgangskontrollService(ansattService)
 	private val tiltaksarrangorService =
 		TiltaksarrangorService(
@@ -71,6 +77,7 @@ class TiltaksarrangorServiceTest {
 			endringsmeldingRepository,
 			auditLoggerService,
 			tilgangskontrollService,
+			forslagService,
 		)
 
 	@AfterEach

--- a/src/test/kotlin/no/nav/tiltaksarrangor/testutils/Testdata.kt
+++ b/src/test/kotlin/no/nav/tiltaksarrangor/testutils/Testdata.kt
@@ -7,6 +7,7 @@ import no.nav.tiltaksarrangor.ingest.model.EndringsmeldingType
 import no.nav.tiltaksarrangor.ingest.model.Innhold
 import no.nav.tiltaksarrangor.ingest.model.Kontaktadresse
 import no.nav.tiltaksarrangor.ingest.model.Matrikkeladresse
+import no.nav.tiltaksarrangor.ingest.model.NavAnsatt
 import no.nav.tiltaksarrangor.ingest.model.Vegadresse
 import no.nav.tiltaksarrangor.ingest.model.VurderingDto
 import no.nav.tiltaksarrangor.model.DeltakerlisteStatus
@@ -158,4 +159,12 @@ fun getKoordinator(
 	roller = listOf(AnsattRolleDbo(arrangorId, AnsattRolle.KOORDINATOR)),
 	deltakerlister = listOf(KoordinatorDeltakerlisteDbo(deltakerlisteId)),
 	veilederDeltakere = emptyList(),
+)
+
+fun getNavAnsatt(id: UUID = UUID.randomUUID()) = NavAnsatt(
+	id = id,
+	navident = (100000..999999).random().toString(),
+	navn = "Veileder Veiledersen",
+	epost = "epost@nav.no",
+	telefon = "99999999",
 )

--- a/src/test/kotlin/no/nav/tiltaksarrangor/testutils/Testdata.kt
+++ b/src/test/kotlin/no/nav/tiltaksarrangor/testutils/Testdata.kt
@@ -170,8 +170,8 @@ fun getNavAnsatt(id: UUID = UUID.randomUUID()) = NavAnsatt(
 	telefon = "99999999",
 )
 
-fun getNavEnhet() = NavEnhet(
-	id = UUID.randomUUID(),
+fun getNavEnhet(id: UUID = UUID.randomUUID()) = NavEnhet(
+	id = id,
 	enhetId = (100000..999999).random().toString(),
 	navn = "NAV Grünerløkka",
 )

--- a/src/test/kotlin/no/nav/tiltaksarrangor/testutils/Testdata.kt
+++ b/src/test/kotlin/no/nav/tiltaksarrangor/testutils/Testdata.kt
@@ -8,6 +8,7 @@ import no.nav.tiltaksarrangor.ingest.model.Innhold
 import no.nav.tiltaksarrangor.ingest.model.Kontaktadresse
 import no.nav.tiltaksarrangor.ingest.model.Matrikkeladresse
 import no.nav.tiltaksarrangor.ingest.model.NavAnsatt
+import no.nav.tiltaksarrangor.ingest.model.NavEnhet
 import no.nav.tiltaksarrangor.ingest.model.Vegadresse
 import no.nav.tiltaksarrangor.ingest.model.VurderingDto
 import no.nav.tiltaksarrangor.model.DeltakerlisteStatus
@@ -167,4 +168,10 @@ fun getNavAnsatt(id: UUID = UUID.randomUUID()) = NavAnsatt(
 	navn = "Veileder Veiledersen",
 	epost = "epost@nav.no",
 	telefon = "99999999",
+)
+
+fun getNavEnhet() = NavEnhet(
+	id = UUID.randomUUID(),
+	enhetId = (100000..999999).random().toString(),
+	navn = "NAV Grünerløkka",
 )

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -35,6 +35,13 @@ no.nav.security.jwt.client.registration.amt-arrangor-aad.authentication.client-i
 no.nav.security.jwt.client.registration.amt-arrangor-aad.authentication.client-secret=secret
 no.nav.security.jwt.client.registration.amt-arrangor-aad.authentication.client-auth-method=client_secret_basic
 
+no.nav.security.jwt.client.registration.amt-person-aad.token-endpoint-url=http://localhost:${mock-oauth2-server.port}/azureator/token
+no.nav.security.jwt.client.registration.amt-person-aad.grant-type=client_credentials
+no.nav.security.jwt.client.registration.amt-person-aad.scope=amt-person
+no.nav.security.jwt.client.registration.amt-person-aad.authentication.client-id=clientid
+no.nav.security.jwt.client.registration.amt-person-aad.authentication.client-secret=secret
+no.nav.security.jwt.client.registration.amt-person-aad.authentication.client-auth-method=client_secret_basic
+
 app.env.unleashUrl=https://amt-unleash.nais.io/api/
 app.env.unleashApiToken=token
 


### PR DESCRIPTION
Jeg innså litt sent at jeg trenger faktisk ikke å mappe alle mulige typer forslag og statuser når vi ikke enda har historikk, og på aktive forslag så vises jo så klart ikke noe nav informasjon (eller arrangør informasjon). Så alt med nav-ansatt og enhet er litt unødvendig her, men vi trenger det fortsatt når vi kommer til historikken.