### PR TITLE
Ikke slett arrangøransatt bare fordi de ikke har noen roller

### DIFF
--- a/src/main/kotlin/no/nav/tiltaksarrangor/ingest/IngestService.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/ingest/IngestService.kt
@@ -61,7 +61,7 @@ class IngestService(
 	}
 
 	fun lagreAnsatt(ansattId: UUID, ansatt: AnsattDto?) {
-		if (ansatt == null || ansatt.arrangorer.isEmpty()) {
+		if (ansatt == null) {
 			ansattRepository.deleteAnsatt(ansattId)
 			log.info("Slettet ansatt med id $ansattId")
 		} else {


### PR DESCRIPTION
Hvis de ligger igjen som ansvarlig ansatt på et forslag så feiler slettingen. Vi sletter alle roller og tilganger uansett ved å oppdatere den ansatte.