### PR TITLE
Vurderinger

### DIFF
--- a/src/main/kotlin/no/nav/tiltaksarrangor/service/TiltaksarrangorService.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/service/TiltaksarrangorService.kt
@@ -40,7 +40,7 @@ class TiltaksarrangorService(
 	private val arrangorRepository: ArrangorRepository,
 	private val meldingProducer: MeldingProducer,
 	private val ulestEndringRepository: UlestEndringRepository,
-	private val unleashService: UnleashService
+	private val unleashService: UnleashService,
 ) {
 	private val log = LoggerFactory.getLogger(javaClass)
 
@@ -145,7 +145,7 @@ class TiltaksarrangorService(
 			begrunnelse = request.begrunnelse,
 		)
 
-		if(!unleashService.erKometMasterForTiltakstype(deltakerMedDeltakerliste.deltakerliste.tiltakType)){
+		if (!unleashService.erKometMasterForTiltakstype(deltakerMedDeltakerliste.deltakerliste.tiltakType)) {
 			amtTiltakClient.registrerVurdering(deltakerId, vurdering.toRegistrerVurderingRequest())
 		}
 		meldingProducer.produce(vurdering)

--- a/src/main/kotlin/no/nav/tiltaksarrangor/unleash/UnleashService.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/unleash/UnleashService.kt
@@ -17,7 +17,11 @@ class UnleashService(
 	)
 
 	// her kan vi legge inn de neste tiltakstypene vi skal ta over
-	private val tiltakstyperKometKanskjeErMasterFor = emptyList<String>()
+	private val tiltakstyperKometKanskjeErMasterFor = listOf(
+		"JOBBK",
+		"GRUPPEAMO",
+		"GRUFAGYRKE",
+	)
 
 	fun erKometMasterForTiltakstype(tiltakstype: String): Boolean = tiltakstype in tiltakstyperKometAlltidErMasterFor ||
 		(unleash.isEnabled("amt.enable-komet-deltakere") && tiltakstype in tiltakstyperKometKanskjeErMasterFor)

--- a/src/test/kotlin/no/nav/tiltaksarrangor/endringsmelding/controller/EndringsmeldingControllerTest.kt
+++ b/src/test/kotlin/no/nav/tiltaksarrangor/endringsmelding/controller/EndringsmeldingControllerTest.kt
@@ -1,5 +1,4 @@
 package no.nav.tiltaksarrangor.endringsmelding.controller
-
 import io.kotest.matchers.shouldBe
 import no.nav.tiltaksarrangor.IntegrationTest
 import no.nav.tiltaksarrangor.endringsmelding.controller.request.EndringsmeldingRequest
@@ -57,10 +56,11 @@ class EndringsmeldingControllerTest : IntegrationTest() {
 	fun `getAlleEndringsmeldinger - autentisert - returnerer 200`() {
 		val personIdent = "12345678910"
 		val arrangorId = UUID.randomUUID()
-		val deltakerliste = getDeltakerliste(arrangorId).copy(tiltakType = "JOBBK")
+		val deltakerliste = getDeltakerliste(arrangorId).copy(tiltakType = "TILTAKSTYPE")
 		deltakerlisteRepository.insertOrUpdateDeltakerliste(deltakerliste)
 		val deltakerId = UUID.fromString("977350f2-d6a5-49bb-a3a0-773f25f863d9")
 		deltakerRepository.insertOrUpdateDeltaker(getDeltaker(deltakerId, deltakerliste.id))
+
 		ansattRepository.insertOrUpdateAnsatt(
 			AnsattDbo(
 				id = UUID.randomUUID(),

--- a/src/test/kotlin/no/nav/tiltaksarrangor/service/TiltaksarrangorServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltaksarrangor/service/TiltaksarrangorServiceTest.kt
@@ -101,6 +101,7 @@ class TiltaksarrangorServiceTest {
 			arrangorRepository,
 			meldingProducer,
 			ulestEndringRepository,
+			unleashService,
 		)
 
 	@AfterEach


### PR DESCRIPTION
det er også en sjekk i amt-tiltak som sørger for at endringene ikke ville havnet på topic uansett, men denne endringen sørger for at 
- amt-tiltak APIet ikke blir kalt og derfor ikke lagrer en vurdering når den uansett ikke skal det
- Vi APIet kalles før vi legger data på kafka sånn at gitt at api kall feiler så legger vi ikke på kafka og det vil feiler