### PR TITLE
Når deltaker hentes ut så skal innhold være null hvis både ledetekst og innholdsliste mangler. Dette vil kunne skje på kurs

### DIFF
--- a/src/main/kotlin/no/nav/tiltaksarrangor/service/DeltakerMapper.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/service/DeltakerMapper.kt
@@ -118,7 +118,13 @@ private fun tilDeltaker(
 		soktInnDato = deltakerDbo.innsoktDato.atStartOfDay(),
 		tiltakskode = deltakerliste.tiltakType,
 		bestillingTekst = deltakerDbo.bestillingstekst,
-		innhold = deltakerDbo.innhold,
+		innhold = deltakerDbo.innhold?.let {
+			if (deltakerDbo.innhold.innhold.isEmpty() && deltakerDbo.innhold.ledetekst == null) {
+				null
+			} else {
+				deltakerDbo.innhold
+			}
+		},
 		fjernesDato = deltakerDbo.skalFjernesDato(),
 		navInformasjon =
 			NavInformasjon(


### PR DESCRIPTION
Retter feil med at deltaker deltaljer ikke kan lastes inn på noen kurstiltak