### PR TITLE
Bump dependencies - 20250708105509

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,9 @@ dependencies {
     implementation("io.micrometer:micrometer-registry-prometheus")
     implementation("net.logstash.logback:logstash-logback-encoder:$logstashEncoderVersion")
     implementation("no.nav.common:audit-log:$commonVersion")
-    implementation("no.nav.common:log:$commonVersion")
+    implementation("no.nav.common:log:$commonVersion") {
+        exclude("com.squareup.okhttp3", "okhttp")
+    }
 
     implementation("org.springframework.kafka:spring-kafka")
     implementation("org.apache.kafka:kafka-clients:$kafkaClientsVersion")
@@ -81,6 +83,7 @@ dependencies {
     testImplementation("org.awaitility:awaitility")
     testImplementation("io.mockk:mockk:$mockkVersion")
     testImplementation("no.nav.amt.lib:testing:$amtLibVersion")
+    testImplementation("com.squareup.okhttp3:mockwebserver:$okHttpVersion")
 }
 
 tasks.getByName<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250708105509 branch:

## Successfully Rebased PRs
- [Bump io.getunleash:unleash-client-java from 11.0.1 to 11.0.2](https://github.com/navikt/amt-tiltaksarrangor-bff/pull/413)
- [Bump com.squareup.okhttp3:okhttp from 4.12.0 to 5.0.0](https://github.com/navikt/amt-tiltaksarrangor-bff/pull/412)


