### PR TITLE
Flyttet default verdi for @Value til application.properties

### DIFF
--- a/src/main/kotlin/no/nav/tiltaksarrangor/api/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/tiltaksarrangor/api/GlobalExceptionHandler.kt
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 
 @ControllerAdvice
 class GlobalExceptionHandler(
-	@Value("\${rest.include-stacktrace: false}") private val includeStacktrace: Boolean,
+	@Value($$"${rest.include-stacktrace}") private val includeStacktrace: Boolean,
 ) {
 	private val log = LoggerFactory.getLogger(javaClass)
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -63,3 +63,5 @@ spring.datasource.hikari.maximum-pool-size=3
 spring.flyway.postgresql.transactional-lock=false
 
 kafka.auto-offset-reset=earliest
+
+rest.include-stacktrace=false


### PR DESCRIPTION
Endring for å gjøre det enklere å verifisere entries i application.properties i IntelliJ.

Mulig feil: Ser at `elector.path` ikke har entry i application.properties, kun i application-test.properties. Kan du sjekke @tofoss ?